### PR TITLE
Add sign typed message

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
   "license": "MIT",
   "dependencies": {
     "@trufflesuite/web3-provider-engine": "^15.0.13-1",
-    "@types/web3": "^1.2.2",
-    "@types/web3-provider-engine": "^14.0.0",
     "number-to-bn": "^1.7.0",
     "typescript": "^4.2.4",
     "web3": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "number-to-bn": "^1.7.0",
     "typescript": "^4.2.4",
     "web3": "^1.3.5",
-    "web3-provider-engine": "habdelra/web3-provider-engine"
+    "web3-provider-engine": "habdelra/web3-provider-engine",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "eslint": "^7.24.0",

--- a/trezor-wallet-provider.js
+++ b/trezor-wallet-provider.js
@@ -119,11 +119,11 @@ class Trezor {
     const path = this.opts.derivationPath
       ? this.opts.derivationPath
       : `${this.opts.derivationPathPrefix}/${idx}`;
+    // tmp file created because `ethereum sign-typed-data` takes file path as input.
     tmp.file(
       { postfix: ".json", prefix: "typedData--" },
       function _tempFileCreated(err, filePath, fd, cleanupCallback) {
         if (err) throw err;
-        // tmp file created because `ethereum sign-typed-data` takes file path as input
         let response;
         fs.writeFileSync(filePath, JSON.stringify(data), function (err) {
           if (err) throw err;

--- a/trezor-wallet-provider.js
+++ b/trezor-wallet-provider.js
@@ -121,7 +121,7 @@ class Trezor {
       : `${this.opts.derivationPathPrefix}/${idx}`;
     // tmp file created because `ethereum sign-typed-data` takes file path as input.
     tmp.file(
-      { postfix: ".json", prefix: "typedData--" },
+      { postfix: ".json" },
       function _tempFileCreated(err, filePath, fd, cleanupCallback) {
         if (err) throw err;
         let response;

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,13 +604,6 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/ethereum-protocol@*":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz#04bb8a91824a5ee2fae959cc788412321350a75d"
-  integrity sha512-vxym5Cnkvms5yRwCDzuaavAtesRflY4oqYDULqQSghLmX5snurmDEz+rbUJbq2vDc4TBvji6dV+891N3VHQXhw==
-  dependencies:
-    bignumber.js "7.2.1"
-
 "@types/http-cache-semantics@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
@@ -658,20 +651,6 @@
   integrity sha512-QMg+9v0bbNJ2peLuHRWxzmy0HRJIG6gFZNhaRSp7S3ggSbCCxiqQB2/ybvhXyhHOCequpNkrx7OavNhrWOsW0A==
   dependencies:
     "@types/node" "*"
-
-"@types/web3-provider-engine@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@types/web3-provider-engine/-/web3-provider-engine-14.0.0.tgz#43adc3b39dc9812b82aef8cd2d66577665ad59b0"
-  integrity sha512-yHr8mX2SoX3JNyfqdLXdO1UobsGhfiwSgtekbVxKLQrzD7vtpPkKbkIVsPFOhvekvNbPsCmDyeDCLkpeI9gSmA==
-  dependencies:
-    "@types/ethereum-protocol" "*"
-
-"@types/web3@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.2.2.tgz#d95a101547ce625c5ebd0470baa5dbd4b9f3c015"
-  integrity sha512-eFiYJKggNrOl0nsD+9cMh2MLk4zVBfXfGnVeRFbpiZzBE20eet4KLA3fXcjSuHaBn0RnQzwLAGdgzgzdet4C0A==
-  dependencies:
-    web3 "*"
 
 abstract-leveldown@~2.6.0:
   version "2.6.3"
@@ -941,11 +920,6 @@ before-after-hook@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
   integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
-
-bignumber.js@7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
-  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
 
 bignumber.js@^9.0.0:
   version "9.0.1"
@@ -4521,7 +4495,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -4974,6 +4948,13 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -5511,7 +5492,7 @@ web3-utils@1.3.5:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3@*, web3@^1.3.5:
+web3@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.3.5.tgz#ef4c3a2241fdd74f2f7794e839f30bc6f9814e46"
   integrity sha512-UyQW/MT5EIGBrXPCh/FDIaD7RtJTn5/rJUNw2FOglp0qoXnCQHNKvntiR1ylztk05fYxIF6UgsC76IrazlKJjw==


### PR DESCRIPTION
In an effort to support cli-signing with trezor wallet provider, I have added:

- `signTypedMessage` method to support EIP712. This is the method required by the `HookedWalletProvider` dependency [here](https://github.com/trufflesuite/provider-engine/blob/24ded488077470add1fcb68cdba80fd8419b83bb/subproviders/hooked-wallet.js#L82)
- Possible quirk about this PR is I needed to create tmp file because `trezorctl` only takes in filePath as a command line argument

**How to test?**

Most of my testing has been using the cli. TBD making a pr so it can be tested easily tested with cli. [pr is here](https://github.com/cardstack/cardstack/pull/2795).
